### PR TITLE
Add aarch64 to install arch map

### DIFF
--- a/roles/install/vars/main.yml
+++ b/roles/install/vars/main.yml
@@ -20,6 +20,7 @@
 #
 install_package_arch_map:
   x86_64: "amd64"
+  aarch64: "arm64"
 
 install_package_base_url: "https://releases.hashicorp.com/{{ install_package_name }}"
 install_package_check_url: "https://checkpoint-api.hashicorp.com/v1/check/{{ install_package_name }}"


### PR DESCRIPTION
Hi,
I tried to install nomad in a multipass box on apple silicon and it complains about the arch `aarch64`. Mapping `aarch64` to `arm64` solves the issue.

Thanks for your great work
Lars